### PR TITLE
add burnin options for plotting

### DIFF
--- a/hpvsim/parameters.py
+++ b/hpvsim/parameters.py
@@ -42,7 +42,8 @@ def make_pars(set_prognoses=False, **kwargs):
     # Simulation parameters
     pars['start']           = 2015.         # Start of the simulation
     pars['end']             = None          # End of the simulation
-    pars['n_years']         = 10.           # Number of years to run, if end isn't specified
+    pars['n_years']         = 15            # Number of years to run, if end isn't specified. Note that this includes burn-in
+    pars['burnin']          = 5             # Number of years of burnin. NB, this is doesn't affect the start and end dates of the simulation, but it is possible remove these years from plots
     pars['dt']              = 0.2           # Timestep (in years)
     pars['rand_seed']       = 1             # Random seed, if None, don't reset
     pars['verbose']         = hpo.verbose   # Whether or not to display information during the run -- options are 0 (silent), 0.1 (some; default), 1 (default), 2 (everything)
@@ -113,7 +114,6 @@ def make_pars(set_prognoses=False, **kwargs):
 
     # Efficacy of protection
     pars['eff_condoms']     = 0.7  # The efficacy of condoms; https://www.nejm.org/doi/10.1056/NEJMoa053284?url_ver=Z39.88-2003&rfr_id=ori:rid:crossref.org&rfr_dat=cr_pub%20%200www.ncbi.nlm.nih.gov
-
 
     # Events and interventions
     pars['interventions'] = []   # The interventions present in this simulation; populated by the user

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -23,7 +23,8 @@ def test_network(do_plot=True):
     n_agents = 50e3
     pars = dict(pop_size=n_agents,
                 start=1990,
-                n_years=30,
+                n_years=40,
+                burnin=10,
                 dt=0.5,
                 pop_scale=25.2e6/n_agents,
                 network='default',

--- a/tests/test_sim.py
+++ b/tests/test_sim.py
@@ -53,16 +53,6 @@ def test_sim(do_plot=False, do_save=False): # If being run via pytest, turn off
         sim.run(verbose=verbose)
         sim.plot(do_save=do_save)
 
-        # Plot age mixing
-        import pylab as pl
-        pl.rcParams.update({'font.size': 22})
-        fig, ax = pl.subplots(figsize=(12,8))
-        h = ax.hist2d(sim.people.contacts['a']['age_f'], sim.people.contacts['a']['age_m'], bins=np.linspace(0,100,21))
-        ax.set_xlabel('Age of female partner')
-        ax.set_ylabel('Age of male partner')
-        fig.colorbar(h[3], ax=ax)
-        pl.show()
-
     return sim
 
 


### PR DESCRIPTION
Small changes so that the initial (burnin) years can be excised from the plots.

Most of the other functionality we would want for burn-in is already there thanks to `sim.run(until)`, e.g. we could run start the sim in 1950, run until 2020, cut the first 40 years from the plots, and then run scenarios from 2020 onwards. So I think this addresses #51 