### PR TITLE
Make waning optional

### DIFF
--- a/hpvsim/defaults.py
+++ b/hpvsim/defaults.py
@@ -116,9 +116,9 @@ class PeopleMeta(sc.prettyobj):
 # Flows: we count new and cumulative totals for each
 # All are stored (1) by genotype and (2) as the total across genotypes
 # the by_age vector tells the sim which results should be stored by age - should have entries in [None, 'total', 'genotype', 'both']
-flow_keys   = ['infections',    'cin1s',        'cin2s',        'cin3s',        'cins',         'cancers',  'cancer_deaths',    'reinfections',     'doses',        'vaccinated',   'screens',  'screened']
-flow_names  = ['infections',    'CIN1s',        'CIN2s',        'CIN3s',        'CINs',         'cancers',  'cancer deaths',    'reinfections',     'doses',        'vaccinated',   'screens',  'screened']
-flow_colors = [pl.cm.GnBu,      pl.cm.Oranges,  pl.cm.Oranges,  pl.cm.Oranges,  pl.cm.Oranges,  pl.cm.Reds, pl.cm.Purples,      pl.cm.GnBu,          pl.cm.Oranges,  pl.cm.Oranges, pl.cm.Purples, pl.cm.Purples,]
+flow_keys   = ['infections',    'cin1s',        'cin2s',        'cin3s',        'cins',         'cancers',  'cancer_deaths',    'reinfections',     'screens',  'screened']
+flow_names  = ['infections',    'CIN1s',        'CIN2s',        'CIN3s',        'CINs',         'cancers',  'cancer deaths',    'reinfections',     'screens',  'screened']
+flow_colors = [pl.cm.GnBu,      pl.cm.Oranges,  pl.cm.Oranges,  pl.cm.Oranges,  pl.cm.Oranges,  pl.cm.Reds, pl.cm.Purples,      pl.cm.GnBu,          pl.cm.Purples, pl.cm.Purples,]
 
 # Stocks: the number in each of the following states
 # All are stored (1) by genotype and (2) as the total across genotypes

--- a/hpvsim/immunity.py
+++ b/hpvsim/immunity.py
@@ -91,10 +91,11 @@ def init_immunity(sim, create=False):
     if sim['immunity'] is None or create:
 
         # Precompute waning - same for all genotypes
-        imm_decay = sc.dcp(sim['imm_decay'])
-        if 'half_life' in imm_decay.keys():
-            imm_decay['half_life'] /= sim['dt']
-        sim['imm_kin'] = precompute_waning(t=sim.tvec, pars=imm_decay)
+        if sim['use_waning']:
+            imm_decay = sc.dcp(sim['imm_decay'])
+            if 'half_life' in imm_decay.keys():
+                imm_decay['half_life'] /= sim['dt']
+            sim['imm_kin'] = precompute_waning(t=sim.tvec, pars=imm_decay)
 
         sim['immunity_map'] = dict()
         # Firstly, initialize immunity matrix with defaults. These are then overwitten with genotype-specific values below
@@ -155,8 +156,7 @@ def update_peak_immunity(people, inds, imm_pars, imm_source, offset=None, infect
             people.peak_imm[imm_source, prior_imm_inds] *= is_seroconvert[has_imm] * boost
 
         if len(no_prior_imm_inds):
-            people.peak_imm[imm_source, no_prior_imm_inds] = is_seroconvert[~has_imm] * hpu.sample(
-                **imm_pars['imm_init'], size=len(no_prior_imm_inds))
+            people.peak_imm[imm_source, no_prior_imm_inds] = is_seroconvert[~has_imm] * hpu.sample(**imm_pars['imm_init'], size=len(no_prior_imm_inds))
 
     else:
         # Vaccination by dose
@@ -174,6 +174,7 @@ def update_peak_immunity(people, inds, imm_pars, imm_source, offset=None, infect
 
     base_t = people.t + offset if offset is not None else people.t
     people.t_imm_event[imm_source, inds] = base_t
+
     return
 
 

--- a/hpvsim/parameters.py
+++ b/hpvsim/parameters.py
@@ -47,6 +47,7 @@ def make_pars(set_prognoses=False, **kwargs):
     pars['dt']              = 0.2           # Timestep (in years)
     pars['rand_seed']       = 1             # Random seed, if None, don't reset
     pars['verbose']         = hpo.verbose   # Whether or not to display information during the run -- options are 0 (silent), 0.1 (some; default), 1 (default), 2 (everything)
+    pars['use_waning']      = False         # Whether or not to use waning immunity. If set to False, immunity from infection and vaccination is assumed to stay at the same level permanently
 
     # Network parameters, generally initialized after the population has been constructed
     pars['debut']           = dict(f=dict(dist='normal', par1=18.6, par2=2.1), # Location-specific data should be used here if possible

--- a/hpvsim/sim.py
+++ b/hpvsim/sim.py
@@ -155,7 +155,7 @@ class Sim(hpb.BaseSim):
         creation, rather than before.
         '''
 
-        # Handle nab sources, as we need to init the people and interventions first
+        # Handle sources, as we need to init the people and interventions first
         self.pars['n_imm_sources'] = self.pars['n_genotypes'] + len(self.pars['vaccine_map'])
         for key in self.people.meta.imm_states:
             if key == 't_imm_event':
@@ -609,10 +609,13 @@ class Sim(hpb.BaseSim):
         contacts = people.contacts # Shorten
 
         # Assign sus_imm values, i.e. the protection against infection based on prior immune history
-        has_imm = hpu.true(people.peak_imm.sum(axis=0)).astype(hpd.default_int)
-        if len(has_imm):
-            hpu.update_immunity(people.imm, t, people.t_imm_event, has_imm, imm_kin_pars, people.peak_imm)
-        hpimm.check_immunity(people)
+        if self['use_waning']:
+            has_imm = hpu.true(people.peak_imm.sum(axis=0)).astype(hpd.default_int)
+            if len(has_imm):
+                hpu.update_immunity(people.imm, t, people.t_imm_event, has_imm, imm_kin_pars, people.peak_imm)
+            hpimm.check_immunity(people)
+        else:
+            people.imm = people.peak_imm
 
         # Precalculate aspects of transmission that don't depend on genotype (acts, condoms)
         fs, ms, frac_acts, whole_acts, effective_condoms = [], [], [], [], []

--- a/hpvsim/utils.py
+++ b/hpvsim/utils.py
@@ -259,6 +259,7 @@ def set_prognoses(people, inds, g, dur_hpv):
     # Record eventual deaths from cancer (NB, assuming no survival without treatment)
     dur_cancer = sample(**people.pars['dur_cancer'], size=len(cancer_inds))
     people.date_dead_cancer[g, cancer_inds] = people.date_cancerous[g, cancer_inds] + np.ceil(dur_cancer / dt)
+
     return
 
 


### PR DESCRIPTION
In Covasim, setting `use_waning=False` means that it's not possible to use multiple variants or complex vaccination interventions. That's not the case here - setting `use_waning=False` just means that immunity doesn't decay. In that sense, it's no different to setting `pars['imm_decay'] = dict(form='exp_decay', init_val=1, half_life=None)`, although it's very slightly faster.

Addresses #95 