### PR TITLE
Add scheduler

### DIFF
--- a/hpvsim/interventions.py
+++ b/hpvsim/interventions.py
@@ -283,7 +283,7 @@ class Intervention:
 
 
 #%% Behavior change interventions
-__all__ += ['dynamic_pars']
+__all__ += ['dynamic_pars', 'EventSchedule', 'set_intervention_attributes']
 
 class dynamic_pars(Intervention):
     '''
@@ -374,6 +374,69 @@ class dynamic_pars(Intervention):
                 else:
                     sim[parkey] = val # Set the parameter if not a dict
         return
+
+
+class EventSchedule(Intervention):
+    """
+    Run functions on different days
+
+    This intervention is a a kind of generalization of `dynamic_pars` to allow more
+    flexibility in triggering multiple, arbitrary operations and to more easily assemble
+    multiple changes at different times. This intervention can be used to implement scale-up
+    or other changes to interventions without needing to implement time-dependency in the
+    intervention itself.
+
+    To use the intervention, simply index the intervention by `t` or by date, and then
+    Example:
+
+    >>> iv = EventSchedule()
+    >>> iv[1] = lambda sim: print(sim.t)
+    >>> iv['2020-04-02'] = lambda sim: print('foo')
+
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.schedule = defaultdict(list)
+
+    def __getitem__(self, day):
+        return self.schedule[day]
+
+    def __setitem__(self, day, fcn):
+        if day in self.schedule:
+            raise Exception("Use a list instead to assign multiple functions - or to really overwrite, delete the function for this day first i.e. `del schedule[day]` before performing `schedule[day]=...`")
+        self.schedule[day] = fcn
+
+    def __delitem__(self, key):
+        del self.schedule[key]
+
+    def initialize(self, sim):
+        super().initialize(sim)
+
+        # First convert all values into lists (i.e., wrap any standalone functions into lists)
+        for k, v in list(self.schedule.items()):
+            self.schedule[k] = [v] if not isinstance(self.schedule[k], list) else v
+
+        # Then convert any dates into time indices
+        for k, v in list(self.schedule.items()):
+            t = sim.get_t(k)[0]
+            if t != k:
+                self.schedule[t] += v
+                del self.schedule[k]
+
+    def apply(self, sim):
+        if sim.t in self.schedule:
+            for fcn in self.schedule[sim.t]:
+                fcn(sim)
+
+
+def set_intervention_attributes(sim, intervention_name, **kwargs):
+    # This is a helper method that can be used to set arbitrary intervention attributes
+    # It's a separately defined function so that it can be pickled properly
+    iv = sim.get_intervention(intervention_name)
+    for attr, value in kwargs.items():
+        assert hasattr(iv, attr), "set_intervention_attributes() should only be used to change existing attributes"  # avoid silent errors if the attr is misspelled
+        setattr(iv, attr, value)
 
 
 #%% Vaccination

--- a/tests/test_event_schedule.py
+++ b/tests/test_event_schedule.py
@@ -1,0 +1,44 @@
+'''
+Tests for event scheduler
+'''
+
+import sciris as sc
+import numpy as np
+import hpvsim as hpv
+import functools
+
+class simple_vaccinate_prob(hpv.vaccinate_prob):
+    # Simplified vaccination routine that delivers vaccine to everyone every day with probability prob
+    def select_people(self, sim):
+        vacc_probs = np.zeros(len(sim.people))
+        vacc_probs[sim.people.alive & ~sim.people.vaccinated] = self.prob  # Assign equal vaccination probability to everyone
+        print(self.prob)
+        return hpv.true(hpv.binomial_arr(vacc_probs))  # Calculate who actually gets vaccinated
+
+
+def test_schedule_scaleup():
+    sc.heading('Test dynamics pars intervention')
+
+    pars = {
+        'n_agents': 1e5,
+        'n_years': 50,
+    }
+
+    vx = simple_vaccinate_prob(vaccine='bivalent', label='vaccine_intervention', timepoints=0, prob=0)
+
+    schedule = hpv.EventSchedule()
+    schedule[10] = functools.partial(hpv.set_intervention_attributes, intervention_name='vaccine_intervention', prob=0.05)
+    schedule['2030-01-01'] = functools.partial(hpv.set_intervention_attributes, intervention_name='vaccine_intervention', prob=0.2)
+    schedule[2040.0] = functools.partial(hpv.set_intervention_attributes, intervention_name='vaccine_intervention', prob=0.4)
+    schedule[2045.0] = functools.partial(hpv.set_intervention_attributes, intervention_name='vaccine_intervention', prob=0.6)
+
+    sim = hpv.Sim(pars=pars, interventions=[vx, schedule])
+    sim.run()
+
+    sim.plot('new_doses')
+    return sim
+
+
+#%% Run as a script
+if __name__ == '__main__':
+    sim  = test_schedule_scaleup()


### PR DESCRIPTION
This PR adds a useful intervention from the Victorian code with a class to facilitate triggering arbitrary changes to the sim. It's been quite useful for adding time-varying intervention attributes without needing to add complexity to the intervention itself