### PR TITLE
Edits to tutorials and docstrings to fix formatting

### DIFF
--- a/docs/_templates/footer.html
+++ b/docs/_templates/footer.html
@@ -1,8 +1,7 @@
 {% extends '!footer.html' %}
 {% block extrafooter %}
-<p>HPVsim is licensed under the <a href="https://creativecommons.org/licenses/by-sa/4.0/legalcode">Creative Commons
-    Attribution-ShareAlike 4.0 International License</a>.</p>
-<p>Send documentation feedback to <a href="mailto:info@covasim.org" target="_top">info@hpvsim.org</a>. If you have
+<p>HPVsim is licensed under the <a href="https://github.com/amath-idm/hpvsim/blob/develop/LICENSE">MIT License</a>.</p>
+<p>If you have
     questions, email <a href="mailto:info@hpvsim.org" target="_top">info@hpvsim.org</a>.</p>
 <p><a href="https://www.gatesfoundation.org/Privacy-and-Cookies-Notice">Privacy and Cookies Notice</a>&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;
 <a href="https://www.gatesfoundation.org/Terms-of-Use">Terms of Use</a></p>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,7 +84,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'HPVsim'
-copyright = f'2022 - {datetime.today().year}, Bill & Melinda Gates Foundation. All rights reserved.\nThese docs were built for {project} version {hpv.__version__}.\n'
+copyright = f'2022 - {datetime.today().year}, Bill & Melinda Gates Foundation. All rights reserved.\nThese docs were built for {project} version {hpv.__version__}\n'
 author = 'Institute for Disease Modeling'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/tutorials/clean_outputs
+++ b/docs/tutorials/clean_outputs
@@ -5,4 +5,4 @@ echo `ls -1 ./my-*.* 2> /dev/null`
 echo '...in 1 second'
 sleep 1
 rm -vf ./my-*.*
-# rm -vf ./covasim_calibration.db
+# rm -vf ./hpvsim_calibration.db

--- a/docs/tutorials/tut_analyzers.ipynb
+++ b/docs/tutorials/tut_analyzers.ipynb
@@ -29,7 +29,7 @@
    "source": [
     "## Results by age\n",
     "\n",
-    "By far the most common reason to use an analyzer is to report results by age. The results in `sim.results` are all aggregated over all ages, whereas data on cervical cancers are generally reported by age. Age-specific outputs can be customized using an analyzer to match the age bins of the data. The following example shows how to set this up:"
+    "By far the most common reason to use an analyzer is to report results by age. The results in `sim.results` are aggregated over all ages, whereas data on cervical cancers are generally reported by age. Age-specific outputs can be customized using an analyzer to match the age bins of the data. The following example shows how to set this up:"
    ]
   },
   {

--- a/docs/tutorials/tut_interventions.ipynb
+++ b/docs/tutorials/tut_interventions.ipynb
@@ -29,10 +29,11 @@
     "HPVsim contains *products*, which can be thought of as the actual test, diagnostic, treatment, or vaccine product being used, as well as *interventions*, which are responsible for delivering the products to the population.\n",
     "Information about the default products included with HPVsim (e.g. attributes like test positivity and efficacy) are available in the `hpvsim/data/products_*.csv` files.\n",
     "Specifically:\n",
-    "* screening products (VIA, HPV testing, and HPV16/18 testing): `hpvsim/data/products_dx.csv`\n",
-    "* triage products (VIA triage, assignment to treatment): `hpvsim/data/products_dx.csv`\n",
-    "* treatment products (ablation, excision, and therapeutic vaccines): `hpvsim/data/products_tx.csv`\n",
-    "* prophylactic vaccine products (bivalent, quadrivalent, nonavalent): `hpvsim/data/products_vx.csv`\n",
+    "\n",
+    "* Screening products (VIA, HPV testing, and HPV16/18 testing): `hpvsim/data/products_dx.csv`\n",
+    "* Triage products (VIA triage, assignment to treatment): `hpvsim/data/products_dx.csv`\n",
+    "* Treatment products (ablation, excision, and therapeutic vaccines): `hpvsim/data/products_tx.csv`\n",
+    "* Prophylactic vaccine products (bivalent, quadrivalent, nonavalent): `hpvsim/data/products_vx.csv` \\n",
     "\n",
     "It's also possible to make a custom product, e.g."
    ]
@@ -61,9 +62,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Custom products can be made for diagnostics and vaccination in the same way. The efficacy of some products varies by genotype, in which case efficacyvalues for each genotype can be entered as separate dataframe rows.\n",
+    "Custom products can be made for diagnostics and vaccination in the same way. The efficacy of some products varies by genotype, in which case efficacy values for each genotype can be entered as separate dataframe rows.\n",
     "\n",
-    "Most of the time, it isn't encessary to create your own products if you just want to use one of the standard options. When setting up screening, triage, or treatment interventions, it's possible to pass in a string that will create a standard default product."
+    "Most of the time, it isn't necessary to create your own products if you just want to use one of the standard options. When setting up screening, triage, or treatment interventions, it's possible to pass in a string that will create a standard default product."
    ]
   },
   {
@@ -72,7 +73,7 @@
    "source": [
     "## Screening and treatment interventions\n",
     "\n",
-    "Screening and treatment is implemented in HPVsim as a flexible set of interventions that can be mixed and matched. By specifying how each of the components link together, it's possible to create quite complex algorithms. THis is illustrated in the following example:"
+    "Screening and treatment is implemented in HPVsim as a flexible set of interventions that can be mixed and matched. By specifying how each of the components link together, it's possible to create quite complex algorithms. This is illustrated in the following example:"
    ]
   },
   {
@@ -140,7 +141,7 @@
    "source": [
     "## Prophylactic vaccination\n",
     "\n",
-    "Prophylactic vaccination within HPVsim simply targets a vaccine product towards a set of the population.\n"
+    "Prophylactic vaccination within HPVsim simply targets a vaccine product towards a subset of the population.\n"
    ]
   },
   {
@@ -181,6 +182,7 @@
     "## Therapeutic vaccination\n",
     "\n",
     "Therapeutic vaccination can be included in a few different formats/use cases:\n",
+    "\n",
     "* As a part of a screen & treat algorithm\n",
     "* As a mass vaccination without screening.\n",
     "\n",

--- a/docs/tutorials/tut_people.ipynb
+++ b/docs/tutorials/tut_people.ipynb
@@ -31,9 +31,10 @@
     "## Demographic data\n",
     "\n",
     "HPVsim includes pre-downloaded demographic data for almost all countries, including:\n",
-    " * population sizes from 1950-2100 from the UN's World Population Projections;\n",
-    " * birth rates from 1950-2100 from the World Bank;\n",
-    " * age- and sex-specific mortality rates from 1950-2100 from the UN's World Population Projections.\n",
+    "\n",
+    " * Population sizes from 1950-2100 from the UN's World Population Projections;\n",
+    " * Birth rates from 1950-2100 from the World Bank;\n",
+    " * Age- and sex-specific mortality rates from 1950-2100 from the UN's World Population Projections.\n",
     "\n",
     " As we saw in Tutorial 1, you can load these data simply by using the `location` parameter. You can show a list of all available locations with `hpv.data.show_locations()`.\n",
     "\n",
@@ -42,8 +43,9 @@
     "Agents in HPVsim are contained in an object called `People`, which contains all of the agents' properties, as well as methods for changing them from one state to another (e.g., from susceptible to infected).\n",
     "\n",
     "HPV transmits via sexual contact, and in HPVsim this is represented by sexual networks that allow agents to interact with one another. For the moment, HPVsim only models heterosexual partnerships. The sexual contact networks in HPVsim can have multiple *contact layers*, with each layer having different properties that characterize sexual contact, including the duration of the contact, age mixing preferences of partners, etc. HPVsim comes with two options for the sexual network:\n",
-    "* the *random* option has a single contact layer. The number of partners that each agent has is Poisson distributed with a mean of 1.\n",
-    "* the *default* option has 3 contact layers, representing marital, casual, and one-off partnership types.\n",
+    "\n",
+    "* The *random* option has a single contact layer. The number of partners that each agent has is Poisson distributed with a mean of 1.\n",
+    "* The *default* option has 3 contact layers, representing marital, casual, and one-off partnership types.\n",
     "\n"
    ]
   }

--- a/docs/tutorials/tut_plotting.ipynb
+++ b/docs/tutorials/tut_plotting.ipynb
@@ -258,7 +258,7 @@
    "source": [
     "sim_orig = hpv.Sim(start=2000, end=2030, label='Load & save example')\n",
     "sim_orig.run(until='2015')\n",
-    "sim_orig.save('my-half-finished-sim.sim') # Note: Covasim always saves the people if the sim isn't finished running yet\n",
+    "sim_orig.save('my-half-finished-sim.sim') # Note: HPVsim always saves the people if the sim isn't finished running yet\n",
     "\n",
     "sim = hpv.load('my-half-finished-sim.sim')\n",
     "sim['beta'] *= 0.3\n",

--- a/docs/tutorials/tut_running.ipynb
+++ b/docs/tutorials/tut_running.ipynb
@@ -71,7 +71,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "However, often (especially when you run the same parameters with different random seeds), you don't care about the individual sims, you want to see the *statistics* for the sims. You can calculate either the mean or the median of the results across all the sims as follows:"
+    "However, you often don't care about the individual sims (especially when you run the same parameters with different random seeds); you want to see the *statistics* for the sims. You can calculate either the mean or the median of the results across all the sims as follows:"
    ]
   },
   {
@@ -194,7 +194,7 @@
    "source": [
     "### Advanced usage\n",
     "\n",
-    "Finally, you can also merge or split different multisims together. Here's an example that's similar to before, except it shows how to run a multisim of different seeds for the same rel_trans_cin3 value, but then merge multisims for different rel_trans_cin3 values together into one multisim:"
+    "Finally, you can also merge or split different multisims together. Here's an example that's similar to before, except it shows how to run a multisim of different seeds for the same `rel_trans_cin3` value, but then merge multisims for different `rel_trans_cin3` values together into one multisim:"
    ]
   },
   {
@@ -234,7 +234,7 @@
    "source": [
     "## Running with Scenarios\n",
     "\n",
-    "Most of the time, you'll want to run with multisims since they give you the most flexibility. However, in certain cases, Scenario objects let you achieve the same thing more simply. Unlike MultiSims, which are completely agnostic about what sims you include, scenarios always start from the same base sim. They then modify the parameters as you specify, and finally add uncertainty if desired. For example, this shows how you'd use scenarios to run the example similar to the one above."
+    "Most of the time, you'll want to run with multisims since they give you the most flexibility. However, in certain cases, Scenario objects let you achieve the same thing more simply. Unlike MultiSims, which are completely agnostic about what sims you include, scenarios always start from the same base sim. They then modify the parameters as you specify, and finally add uncertainty, if desired. For example, this shows how you'd use scenarios to run the example similar to the one above."
    ]
   },
   {

--- a/hpvsim/analysis.py
+++ b/hpvsim/analysis.py
@@ -1030,6 +1030,7 @@ class age_causal_infection(Analyzer):
 class cancer_detection(Analyzer):
     '''
     Cancer detection via symptoms
+    
     Args:
         symp_prob: Probability of having cancer detected via symptoms, rather than screening
         treat_prob: Probability of receiving treatment for those with symptom-detected cancer

--- a/hpvsim/base.py
+++ b/hpvsim/base.py
@@ -324,6 +324,7 @@ class BaseSim(ParsObj):
             t (int or str): the time point in the simulation cloesst to the requested date
 
         **Examples**::
+        
             sim.get_t('2015-03-01') # Get the closest timepoint to the specified date
             sim.get_t(3) # Will return 3
             sim.get_t('2015') # Can use strings

--- a/hpvsim/data/loaders.py
+++ b/hpvsim/data/loaders.py
@@ -215,10 +215,12 @@ def get_total_pop(location=None):
 def get_death_rates(location=None, by_sex=True, overall=False):
     '''
     Load death rates for a given country or countries.
+
     Args:
         location (str or list): name of the country or countries to load the age distribution for
         by_sex (bool): whether to rates by sex
         overall (bool): whether to load total rate
+
     Returns:
         death_rates (dict): death rates by age and sex
     '''
@@ -255,10 +257,12 @@ def get_death_rates(location=None, by_sex=True, overall=False):
 def get_life_expectancy(location=None, by_sex=True, overall=False):
     '''
     Load life expectancy by age for a given country or countries.
+
     Args:
         location (str or list): name of the country or countries to load the age distribution for
         by_sex (bool): whether to rates by sex
         overall (bool): whether to load total rate
+        
     Returns:
         life_expectancy (dict): life expectancy by age and sex
     '''

--- a/hpvsim/interventions.py
+++ b/hpvsim/interventions.py
@@ -557,6 +557,7 @@ __all__ += ['BaseVaccination', 'routine_vx', 'campaign_vx']
 class BaseVaccination(Intervention):
     '''
     Base vaccination class for determining who will receive a vaccine.
+
     Args:
          product        (str/Product)   : the vaccine to use
          prob           (float/arr)     : annual probability of eligible population getting vaccinated
@@ -1179,7 +1180,7 @@ class routine_txvx(BaseTxVx, RoutineDelivery):
 class campaign_txvx(BaseTxVx, CampaignDelivery):
     '''
     Campaign delivery of therapeutic vaccine - an instance of treat_num combined
-     with campaign delivery. See base classes for a description of input arguments.
+    with campaign delivery. See base classes for a description of input arguments.
     '''
 
     def __init__(self, product=None, prob=None, age_range=None, eligibility=None,


### PR DESCRIPTION
There were some formatting issues with bulleted lists in the tutorials. In Binder, the lists looked good but in the static HTML docs they needed the extra blank line or ran together in a single paragraph. I made a few wording changes and copyedits, but overall they looked really good. I also took a very quick look through the API reference just to be sure the formatting wasn't broken a fixed a few issues I saw there. 