### PR TITLE
Limit pandas version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     install_requires=[
         'numpy',
         'scipy',
-        'pandas>=1.4.0', 
+        'pandas>=1.4.0,<2.0.0', 
         'sciris>=2.0.4',
         'matplotlib',
         'seaborn',


### PR DESCRIPTION
Pandas 2.0 breaks the stored data files -- might want to pin the version until we have time to fix it.