### PR TITLE
Fix/575 mismatching shape

### DIFF
--- a/hpvsim/sim.py
+++ b/hpvsim/sim.py
@@ -79,7 +79,9 @@ class Sim(hpb.BaseSim):
         Perform all initializations on the sim.
         '''
         self.t = 0  # The current time index
-        self.validate_pars() # Ensure parameters have valid values
+        self.validate_pars()  # Ensure parameters have valid values
+        self.validate_dt()
+        self.init_time_vecs()  # Initialise time vectors
         hpu.set_seed(self['rand_seed']) # Reset the random seed before the population is created
         self.init_genotypes() # Initialize the genotypes
         self.init_results() # After initializing the genotypes and people, create the results structure
@@ -171,12 +173,12 @@ class Sim(hpb.BaseSim):
         '''
         dt = self['dt']
         reciprocal = 1.0 / dt   # Compute the reciprocal of dt
-        if not reciprocal.is_integer():  # Check if reciprocal is not a whole number
-            # Round the reciprocal to the closest even
+        if not reciprocal.is_integer():  # Check if reciprocal is not a whole (integer) number
+            # Round the reciprocal
             reciprocal = int(reciprocal)
             rounded_dt = 1.0 / reciprocal
             self['dt'] = rounded_dt
-            if self.verbose:
+            if self['verbose']:
                 warnmsg = f"Warning: Provided time step dt: {dt} resulted in a non-integer number of steps/year. Rounded to {rounded_dt}."
                 print(warnmsg)
 


### PR DESCRIPTION
This pull request addresses a specific issue (#575) related to the length of simulation and results arrays. The problem arises from generating simulation time vectors using the `dt` and initialising results vectors based on the condition that `1/dt` is an integer value. As a result, depending on the value of `dt`, the requested results arrays _with an annual frequency_ over a fixed time period (`n_years`) may have varying lengths, as shown in the examples below.

By resolving this issue, the lengths of the results arrays will be consistent, for analyses involving the identical results  frequencies (ie, sampling periods) over fixed time periods.

This PR:
- adds a validation of dt, such that if its reciprocal is not an integer, it will round the value of dt to match the rounding operation during initialisation of result arrays (ie, `int(1/dt)`)  
- performs the validation of dt separately from validation_pars() -- not strictly necessary, but perhaps clearer and may help identifying issue with dt scaling later.
- moves initialisation of simulation time vectors to a separate function for clarity. 

Test code:
```python
import hpvsim as hpv

# Define the parameters
pars = dict(
    n_agents      = 5e3,       # Population size
    start         = 1980,       # Starting year
    n_years       = 50,         # Number of years to simulate
    rand_seed     = 2,          # Set a non-default seed
    genotypes     = [16, 18],   # Include the two genotypes of greatest general interest
    rel_init_prev = 4.0,
)

# Create the sim
sims = []
dts = [0.1, 0.12, 0.875]
for dt in dts:
    sim = hpv.Sim(pars, dt=dt, label=f'dt={dt}')
    sims.append(sim)
msim = hpv.parallel(sims)

sims = msim.sims
for sim in sims:
    print(len(sim.results['year']))
msim.plot()
```

### Before the fix:
When considering multiple values of `dt` for result vectors with the same frequency ('annual'), these do not align one-to-one, and have different lengths. Certain dt values can result in longer result vectors than the expected `n_years + 1` . 

Expected behaviour: all results should start in 2005 and end in 2030 (50 years in n_years, minus the 25 burnin years)

![Screenshot from 2023-06-28 08-35-45](https://github.com/amath-idm/hpvsim/assets/1563810/1a020046-942b-47e9-ad99-be2399d651fe)


### After the fix
When considering multiple values of `dt` for result vectors with the same frequency ('annual'), they all align one-to-one, and have the same length. 


![Screenshot from 2023-06-28 09-01-38](https://github.com/amath-idm/hpvsim/assets/1563810/661393d6-1298-4f2d-b223-481f542c2e3f)



