### PR TITLE
Update imports

### DIFF
--- a/hpvsim/__init__.py
+++ b/hpvsim/__init__.py
@@ -1,3 +1,7 @@
+# This ensures SCIRIS_NUM_THREADS is utilized
+import sciris as sc
+
+# Import HPVsim
 from .version import __version__, __versiondate__, __license__
 from .settings      import *
 from .defaults      import *
@@ -30,5 +34,4 @@ if not data.check_downloaded():
         print(errormsg)
 
 # Set the root directory for the codebase
-import pathlib
-rootdir = pathlib.Path(__file__).parent
+rootdir = sc.thispath(__file__).parent


### PR DESCRIPTION
Previously, Numpy was imported before Sciris so just setting `SCIRIS_NUM_THREADS` wasn't enough for it to take effect. This change isn't worth a new version, but can be incorporated in future versions.

Before:
```py
import os
os.environ['SCIRIS_NUM_THREADS'] = 1
import sciris # otherwise no effect
import hpvsim as hpv
```

Now:
```py
import os
os.environ['SCIRIS_NUM_THREADS'] = 1

import hpvsim as hpv
```