### PR TITLE
for non-genotype specific tests, test result must be true for all gen…

### DIFF
--- a/hpvsim/interventions.py
+++ b/hpvsim/interventions.py
@@ -1295,9 +1295,9 @@ class dx(Product):
             # First check if this is a genotype specific intervention or not
             if len(np.unique(self.df.genotype)) == 1 and np.unique(self.df.genotype)[0]== 'all':
                 if state == 'susceptible':
-                    theseinds = hpu.true(people[state][:, inds].all()) # Must be susceptibile for all genotypes
+                    theseinds = hpu.true(people[state][:, inds].all(axis=0)) # Must be susceptibile for all genotypes
                 else:
-                    theseinds = hpu.true(people[state][:, inds].any()) # Only need to be truly inf/cin/cancerous for one genotype
+                    theseinds = hpu.true(people[state][:, inds].any(axis=0)) # Only need to be truly inf/cin/cancerous for one genotype
                 # Filter the dataframe to extract test results for people in this state
                 df_filter = (self.df.state == state)  # filter by state
                 thisdf = self.df[df_filter]  # apply filter to get the results for this state & genotype


### PR DESCRIPTION
Was having a hard time with getting the tradeoff between sensitivity and specificity right with screening bc of the combination of scrolling through genotypes and the hierarchy. For a screen test that is not genotype specific, if it had a high false positive rate but didn't pick up enough true positives, it would have a hard time showing that because for almost every person they are going to be susceptible to at least one genotype, so they would be flagged as positive for their susceptibility and then negative for their CIN, for example, but the hierarchy would call them positive.

Updates the filtering for tests that are not genotype-specific.